### PR TITLE
Added input validation to directory and file prompts

### DIFF
--- a/lib/prompts/prompts_init.js
+++ b/lib/prompts/prompts_init.js
@@ -1,26 +1,48 @@
+const fs = require('fs');
+
+const validateInput = (input, type, directory) => {
+  const testFile = directory ? `${directory}/${input}` : `${input}`;
+  return fs.existsSync(`${process.env.PWD}/${testFile}`)
+    ? true
+    : `Entered ${type} does not exist`;
+};
+
+let appRoot;
+let bundleRoot;
+
 module.exports = [
+  {
+    type: 'input',
+    name: 'appRoot',
+    message: 'Directory containing the highest level component',
+    validate: input => {
+      appRoot = input;
+      return validateInput(input, 'folder');
+    }
+  },
   {
     type: 'input',
     name: 'app',
     message: 'File containing the highest level component',
-    default: 'app.js'
-  },
-  {
-    type: 'input',
-    name: 'appRoot',
-    message: 'Directory containing the highest level component'
-  },
-  {
-    type: 'input',
-    name: 'bundle',
-    message: 'Bundle file',
-    default: 'bundle.js'
+    default: 'app.js',
+    validate: input => validateInput(input, 'file', appRoot)
   },
   {
     type: 'input',
     name: 'bundleRoot',
     message: 'Bundle output directory',
-    default: 'dist'
+    default: 'dist',
+    validate: input => {
+      bundleRoot = input;
+      return validateInput(input, 'folder');
+    }
+  },
+  {
+    type: 'input',
+    name: 'bundle',
+    message: 'Bundle file',
+    default: 'bundle.js',
+    validate: input => validateInput(input, 'file', bundleRoot)
   },
   {
     type: 'list',

--- a/lib/prompts/prompts_init.js
+++ b/lib/prompts/prompts_init.js
@@ -1,48 +1,42 @@
 const fs = require('fs');
 
-const validateInput = (input, type, directory) => {
-  const testFile = directory ? `${directory}/${input}` : `${input}`;
-  return fs.existsSync(`${process.env.PWD}/${testFile}`)
-    ? true
-    : `Entered ${type} does not exist`;
-};
+// exists takes in a pathString and determines if it exists
+// directoryOrFile takes in a path string and returns a string
 
-let appRoot;
-let bundleRoot;
+const exists = (pathString, fileOrDirectory) => {
+  const absolutePathString = `${process.env.PWD}/${pathString}`;
+  return fs.existsSync(absolutePathString)
+    ? true
+    : `Entered ${fileOrDirectory} does not exist`;
+};
 
 module.exports = [
   {
     type: 'input',
     name: 'appRoot',
     message: 'Directory containing the highest level component',
-    validate: input => {
-      appRoot = input;
-      return validateInput(input, 'folder');
-    }
+    validate: input => exists(input, 'directory')
   },
   {
     type: 'input',
     name: 'app',
     message: 'File containing the highest level component',
     default: 'app.js',
-    validate: input => validateInput(input, 'file', appRoot)
+    validate: (input, answersHash) => exists(`${answersHash.appRoot}/${input}`, 'file')
   },
   {
     type: 'input',
     name: 'bundleRoot',
     message: 'Bundle output directory',
     default: 'dist',
-    validate: input => {
-      bundleRoot = input;
-      return validateInput(input, 'folder');
-    }
+    validate: input => exists(input, 'directory')
   },
   {
     type: 'input',
     name: 'bundle',
     message: 'Bundle file',
     default: 'bundle.js',
-    validate: input => validateInput(input, 'file', bundleRoot)
+    validate: (input, answersHash) => exists(`${answersHash.bundleRoot}/${input}`, 'file')
   },
   {
     type: 'list',


### PR DESCRIPTION
What?
Added input validation for the appRoot, app, bundleRoot, and bundleFile prompts in ribbit init.

Why?
Adds an extra layer of validation to ensure that the user doesn't submit non-existent folders and files. Further checking and/or graceful error & exit messages are still needed in the main program, however.

How (to test):
Install ribbit and run ribbit init in an existing React app. Entering non-existent files and folders should throw a meaningful error message.

Request for feedback:
Do we need any additional validation in the initial prompt?